### PR TITLE
User, Band, Band_Memberモデルの修正

### DIFF
--- a/app/models/band.rb
+++ b/app/models/band.rb
@@ -1,51 +1,9 @@
 class Band < ApplicationRecord
-  validates :name, presence: {message: 'バンド名を入力してください'}
-  validates :master, presence: {message: 'バンマスは必須項目です'}
-  validates :description, presence: {message: '説明を記載してください'}
-  validates :pa, presence: {message: 'PAは必須項目です'}
-
-  def member_datas
-    arr = Array.new()
-    self.members.each do |member|
-      if User.find_by(name: member)
-        arr.push(User.find_by(name: member))
-      else
-        arr.push(User.new())
-      end
-    end
-    return arr
-  end
-  def members
-    BandMember.where(band_id: self.id).pluck('name')
-  end
-  def self.member_repeat?(band1,band2)
-    bool = false
-    band1.members.each do |member|
-      #TODO:配列同士をマージして2個以上あればtrue
-      if band2.members.include?(member)
-        bool = true
-      end
-    end
-    return bool
-  end
-
-  def self.next_band_candidate(bands)
-    next_band_candidate = []
-    bands.each_with_index do |band1,i|
-      candidates = []
-      bands.each_with_index do |band2,i2|
-        unless i == i2
-          if Band.member_repeat?(band1,band2)
-            candidates.push(band2)
-          end
-        end
-      end
-      puts candidates.class
-      next_band_candidate.push(candidates)
-    end
-    return next_band_candidate
-  end
-
-
-
+  validates :name, presence: { message: 'バンド名を入力してください' }
+  validates :master, presence: { message: 'バンマスは必須項目です' }
+  validates :description, presence: { message: '説明を記載してください' }
+  validates :pa, presence: { message: 'PAは必須項目です' }
+  has_many :band_members
+  has_many :users, through: :band_members
+  accepts_nested_attributes_for :band_members
 end

--- a/app/models/band_member.rb
+++ b/app/models/band_member.rb
@@ -1,2 +1,4 @@
 class BandMember < ApplicationRecord
+  belongs_to :user
+  belongs_to :band
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,62 +1,12 @@
-class UserValidator < ActiveModel::Validator
-  def validate(record)
-    if record.name == nil || record.name == ""
-      record.errors[:base] << "名前が入力されていません"
-    end
-    if record.name.include?(" ") || record.name.include?("　")
-      record.errors[:base] << "姓名はスペースを使用せず入力してください"
-    end
-    if record.email == nil
-      record.errors[:base] << "メールアドレスを入力してください"
-    end
-    if record.tel == nil
-      record.errors[:base] << "電話番号を入力してください"
-    end
-    if record.year == nil
-      record.errors[:base] << "入会年度を選択してください"
-    end
-    if record.password == nil
-      record.errors[:base] << "パスワードが入力されていません"
-    end
-  end
-end
-
 class User < ApplicationRecord
   attr_accessor :remember_token
-  validates_with UserValidator
-
-  def bands
-    user_bands = Array.new()
-    Band.all.each do |band|
-      if band.members.include?(self.name)
-        if band.registration
-          user_bands.push(band)
-        end
-      end
-    end
-    return user_bands
-  end
-  def temporal_bands
-    user_bands = Array.new()
-    TemporalBand.all.each do |band|
-      if band.members.include?(self.name)
-          user_bands.push(band)
-      end
-    end
-    return user_bands
-  end
-
-  def band_names
-    user_bands = Array.new()
-    Band.all.each do |band|
-      if band.members.include?(self.name)
-        if band.registration
-          user_bands.push(band.name)
-        end
-      end
-    end
-    return user_bands
-  end
+  validates :name, presence: { message: '名前が入力されていません' }
+  validates :email, presence: { message: 'メールアドレスを入力してください' }
+  validates :tel, presence: { message: '電話番号を入力してください' }
+  validates :year, presence: { message: '入会年度を選択してください' }
+  has_many :band_members
+  has_many :bands, through: :band_members
+  has_secure_password
 
   def mics
     user_mics = Array.new()
@@ -89,45 +39,33 @@ class User < ApplicationRecord
     return user_entries
   end
 
-  def change_status_to_ob_if_graduated
-    #2018年4月1日0:00に2014入会のステータスを全員分OBにする
-    current_year = Date.today.year
-    graduating_year = current_year - 4
-    graduates = User.where(year: graduating_year)
-    graduates.each do |graduate|
-      graduate.status = "OB"
-      graduate.save
-    end
-  end
-
   def self.digest(string)
-    #暗号化
+    # 暗号化
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
   end
 
   def self.new_token
-    #ランダムなトークンを生成する
+    # ランダムなトークンを生成する
     SecureRandom.urlsafe_base64
   end
 
   def remember
     self.remember_token = User.new_token
-    #remember_tokenにランダムなトークンを保存
+    # remember_tokenにランダムなトークンを保存
     update_attribute(:remember_digest,User.digest(remember_token))
-    #remember_digestにremember_tokenをBCryptで暗号化したものを保存
+    # remember_digestにremember_tokenをBCryptで暗号化したものを保存
   end
 
   def authenticated?(remember_token)
     if remember_digest
       BCrypt::Password.new(remember_digest).is_password?(remember_token)
     end
-    #remember_digestは、remember_tokenを暗号化したものか問う
+    # remember_digestは、remember_tokenを暗号化したものか問う
   end
 
   def forget
     update_attribute(:remember_digest, nil)
   end
-
 end

--- a/db/migrate/20180120162957_add_userid_to_bandmembers.rb
+++ b/db/migrate/20180120162957_add_userid_to_bandmembers.rb
@@ -1,0 +1,5 @@
+class AddUseridToBandmembers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :band_members, :user_id, :integer, after: :band_id
+  end
+end

--- a/db/migrate/20180120165400_add_password_digest_to_users_and_delete_password.rb
+++ b/db/migrate/20180120165400_add_password_digest_to_users_and_delete_password.rb
@@ -1,0 +1,7 @@
+class AddPasswordDigestToUsersAndDeletePassword < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :password_digest, :string
+    remove_column :users, :passward_digest
+    remove_column :users, :password
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180102131608) do
+ActiveRecord::Schema.define(version: 20180120165400) do
 
   create_table "band_members", force: :cascade do |t|
     t.integer "band_id"
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
   end
 
   create_table "bands", force: :cascade do |t|
@@ -173,19 +174,17 @@ ActiveRecord::Schema.define(version: 20180102131608) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "username"
     t.string "name"
     t.string "email"
     t.string "tel"
     t.string "univ"
     t.integer "year"
-    t.string "password"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "authority"
     t.boolean "approval", default: false
     t.string "remember_digest"
-    t.string "passward_digest"
+    t.string "password_digest"
   end
 
 end


### PR DESCRIPTION
ユーザーとバンドは多対多の関係だから、Band_Memberを中間テーブルとすればhas_manyを使って簡単に紐付けられる。

これで`user.bands`などで簡単にuserが所属しているバンドをすべて取ってこれたり、band.usersでバンドのメンバーを全員とってこれるようになるので自前でメソッドを定義する必要は不要になる。

参考：https://qiita.com/Kohei_Kishimoto0214/items/cb9a3d3da57708fb52c9
